### PR TITLE
Added ability to save the results of processes trajectories

### DIFF
--- a/mdstates/core.py
+++ b/mdstates/core.py
@@ -103,11 +103,11 @@ class Network:
             for _ in range(len(trajectory)):
                 self.replica.append({'traj': None, 'cmat': None, 'path': None,
                                      'processed': False, 'network': None,
-                                     'smiles': None})
+                                     'smiles': None, 'molecules': None})
         else:
             self.replica.append({'traj': None, 'cmat': None, 'path': None,
                                  'processed': False, 'network': None,
-                                 'smiles': None})
+                                 'smiles': None, 'molecules': None})
         if topology:
             pass
         else:
@@ -419,7 +419,7 @@ class Network:
 
         return
 
-    def _generate_SMILES(self, rep_id, tol=10):
+    def generate_SMILES(self, rep_id, tol=10):
         """Generates list of SMILES strings from trajectory.
 
         Parameters
@@ -849,13 +849,8 @@ class Network:
     def _build_all_networks(self, **kwargs):
         """Builds networks for all replicas."""
         for rep_id, rep in enumerate(self.replica):
-            smiles_list = self._generate_SMILES(rep_id, **kwargs)
+            smiles_list = self.generate_SMILES(rep_id, **kwargs)
             rep['network'] = self._build_network(smiles_list)
-            # if not rep['network']:
-            #     smiles_list = self.generate_SMILES(rep_id, min_lifetime)
-            #     rep['network'] = self._build_network(smiles_list)
-            # else:
-            #     pass
         return
 
     def _draw_network(self, nxgraph, filename, layout="dot", write=True,
@@ -964,7 +959,7 @@ class Network:
             if rep['smiles']:
                 pass
             else:
-                rep['smiles'] = self._generate_SMILES(i, tol=10)
+                rep['smiles'] = self.generate_SMILES(i, tol=10)
 
         with open(name + '.txt', 'w') as f:
             f.write('{}\n'.format(self._first_smiles))
@@ -989,7 +984,8 @@ class Network:
                     rep_id = int(re.search('(?<=replica)\d*', line).group(0))
                     self.replica.append({'traj': None, 'cmat': None,
                                          'path': None, 'processed': False,
-                                         'network': None, 'smiles': None})
+                                         'network': None, 'smiles': None,
+                                         'molecules': None})
                 else:
                     data = line.strip('\n').split(',')
                     data[1] = int(data[1])

--- a/mdstates/core.py
+++ b/mdstates/core.py
@@ -22,6 +22,17 @@ from .util import find_nearest
 __all__ = ['Network']
 
 
+"""TODO:
+    Separate the `replica['smiles']` values into 3 appropriate
+        quantities. Currently `replica['smiles']` holds the
+        SMILES string, the frame number, and the rdkit.RWMol
+        with added explicit hydrogens.
+    Build a new class to replace `Network.replica` attribute.
+        This object should contain all of the information about
+        the replica and should be easily indexed.
+"""
+
+
 class Network:
     """
     Analyze different states and transitions of an MD trajectory.

--- a/mdstates/core.py
+++ b/mdstates/core.py
@@ -605,14 +605,15 @@ class Network:
         if rep_id == -1 and args:
             smiles_list = args[0]
         else:
-            assert self.replica[rep_id]['smiles'], "SMILES list is empty."
-            smiles_list = self.replica[rep_id]['smiles']
+            assert self.replica[rep_id]['structures'],\
+                "Structures list is empty."
+            smiles_list = self.replica[rep_id]['structures']['smiles'].tolist()
 
         chem_eq_list = []
-        for i, (smi, _) in enumerate(smiles_list):
+        for i, smi in enumerate(smiles_list):
             if i == 0:
                 continue
-            chem_eq_list.append(find_reaction(smiles_list[i - 1][0], smi))
+            chem_eq_list.append(find_reaction(smiles_list[i - 1], smi))
 
         return chem_eq_list
 

--- a/mdstates/core.py
+++ b/mdstates/core.py
@@ -939,6 +939,12 @@ class Network:
         name : str
             Name of the checkpoint file.
         """
+        for i, rep in enumerate(self.replica):
+            if rep['smiles']:
+                pass
+            else:
+                rep['smiles'] = self._generate_SMILES(i, tol=10)
+
         with open(name + '.txt', 'w') as f:
             f.write('{}\n'.format(self._first_smiles))
             for i, rep in enumerate(self.replica):
@@ -978,6 +984,9 @@ class Network:
     def build_from_load(self, filename='overall.png', exclude=[],
                         SMILES_loc='SMILESimages', use_LR=False,
                         use_graphviz=False, **kwargs):
+        for rep in self.replica:
+            rep['network'] = self._build_network(rep['smiles'])
+
         compiled = self._compile_networks(exclude=exclude)
         self.network = compiled
         final = prepare_graph(compiled, root_node=self._first_smiles, **kwargs)

--- a/mdstates/molecules.py
+++ b/mdstates/molecules.py
@@ -196,14 +196,15 @@ def set_positive_charges(mol):
 
 def molecule_to_nxgraph(mol):
     """Converts an rdkit molecule to a networkx graph."""
-    mol = Chem.AddHs(mol)
     Chem.Kekulize(mol)
     gmol = nx.Graph()
-    for bond in mol.GetBonds():
-        at1 = bond.GetBeginAtom().GetSymbol()
-        at1_id = bond.GetBeginAtom().GetIdx()
+    for atom in mol.GetAtoms():
+        symbol = atom.GetSymbol()
+        idx = atom.GetIdx()
+        gmol.add_node(idx, symbol=symbol)
 
-        at2 = bond.GetEndAtom().GetSymbol()
+    for bond in mol.GetBonds():
+        at1_id = bond.GetBeginAtom().GetIdx()
         at2_id = bond.GetEndAtom().GetIdx()
 
         if bond.GetBondType() == Chem.BondType.SINGLE:
@@ -215,8 +216,6 @@ def molecule_to_nxgraph(mol):
         else:
             raise Exception("Bond type not recognized.")
 
-        gmol.add_node(at1_id, symbol=at1)
-        gmol.add_node(at2_id, symbol=at2)
         gmol.add_edge(at1_id, at2_id, bond_order=bond_order)
     return gmol
 

--- a/mdstates/molecules.py
+++ b/mdstates/molecules.py
@@ -1,4 +1,5 @@
 import networkx as nx
+from networkx.readwrite import json_graph
 import numpy as np
 from rdkit import Chem
 
@@ -211,6 +212,7 @@ def nxgraph_to_molecule(graph):
 
     Chem.SanitizeMol(mol)
     return mol
+
 
 def nxgraph_to_json(graph):
     """Converts a networkx graph to a json-like dictionary."""

--- a/mdstates/molecules.py
+++ b/mdstates/molecules.py
@@ -161,3 +161,62 @@ def set_positive_charges(mol):
         else:
             pass
     return
+
+
+def molecule_to_nxgraph(mol):
+    """Converts an rdkit molecule to a networkx graph."""
+    mol = Chem.AddHs(mol)
+    Chem.Kekulize(mol)
+    gmol = nx.Graph()
+    for bond in mol.GetBonds():
+        at1 = bond.GetBeginAtom().GetSymbol()
+        at1_id = bond.GetBeginAtom().GetIdx()
+
+        at2 = bond.GetEndAtom().GetSymbol()
+        at2_id = bond.GetEndAtom().GetIdx()
+
+        if bond.GetBondType() == Chem.BondType.SINGLE:
+            bond_order = 1
+        elif bond.GetBondType() == Chem.BondType.DOUBLE:
+            bond_order = 2
+        elif bond.GetBondType() == Chem.BondType.TRIPLE:
+            bond_order = 3
+        else:
+            raise Exception("Bond type not recognized.")
+
+        gmol.add_node(at1_id, symbol=at1)
+        gmol.add_node(at2_id, symbol=at2)
+        gmol.add_edge(at1_id, at2_id, bond_order=bond_order)
+    return gmol
+
+
+def nxgraph_to_molecule(graph):
+    """Converts a networkx graph to an rdkit molecule."""
+    mol = Chem.RWMol()
+    for at, data in sorted(graph.nodes(data=True)):
+        idx = mol.AddAtom(Chem.Atom(data['symbol']))
+        if at != idx:
+            raise Exception("Wrong atom index assigned.")
+        else:
+            pass
+
+    for at1, at2, data in graph.edges(data=True):
+        if data['bond_order'] == 1:
+            bond_order = Chem.BondType.SINGLE
+        elif data['bond_order'] == 2:
+            bond_order = Chem.BondType.DOUBLE
+        elif data['bond_order'] == 3:
+            bond_order = Chem.BondType.TRIPLE
+        mol.AddBond(at1, at2, order=bond_order)
+
+    Chem.SanitizeMol(mol)
+    return mol
+
+def nxgraph_to_json(graph):
+    """Converts a networkx graph to a json-like dictionary."""
+    return json_graph.node_link_data(graph)
+
+
+def json_to_nxgraph(jsgraph):
+    """Converts a json-like dictionary to a networkx graph."""
+    return json_graph.node_link_graph(jsgraph)

--- a/mdstates/molecules.py
+++ b/mdstates/molecules.py
@@ -3,6 +3,8 @@ from networkx.readwrite import json_graph
 import numpy as np
 from rdkit import Chem
 
+from .util import json_to_string, load_json_from_string
+
 
 def contact_matrix_to_SMILES(cmat, atom_list):
     """Converts a contact matrix to a SMILES string.
@@ -250,3 +252,19 @@ def nxgraph_to_json(graph):
 def json_to_nxgraph(jsgraph):
     """Converts a json-like dictionary to a networkx graph."""
     return json_graph.node_link_graph(jsgraph)
+
+
+def molecule_to_json_string(mol):
+    """Converts an rdkit molecule to a json string."""
+    graph = molecule_to_nxgraph(mol)
+    json_dict = nxgraph_to_json(graph)
+    json_string = json_to_string(json_dict)
+    return json_string
+
+
+def json_string_to_molecule(json_string):
+    """Converts a json string to an rdkit molecule."""
+    json_dict = load_json_from_string(json_string)
+    graph = json_to_nxgraph(json_dict)
+    mol = nxgraph_to_molecule(graph)
+    return mol

--- a/mdstates/molecules.py
+++ b/mdstates/molecules.py
@@ -52,15 +52,15 @@ def cmat_to_structure(cmat, atom_list):
     """
 
     # Build the molecule
-    mol = build_molecule(cmat, atom_list)
+    mol = build_molecule(cmat, atom_list, with_hydrogens=True)
 
     # Generate SMILES string from molecule
-    smiles = Chem.MolToSmiles(mol)
+    smiles = Chem.MolToSmiles(Chem.RemoveHs(mol))
 
     return smiles, mol
 
 
-def build_molecule(cmat, atom_list):
+def build_molecule(cmat, atom_list, with_hydrogens=False):
     """Builds a molecule from a contact matrix and list of atoms.
 
     Parameters
@@ -89,9 +89,12 @@ def build_molecule(cmat, atom_list):
     estimate_bonds(mol)
     Chem.SanitizeMol(mol)
 
-    # Remove any unnecessary hydrogens.
-    mol = Chem.RemoveHs(mol)
-    return mol
+    if with_hydrogens:
+        return mol
+    else:
+        # Remove any unnecessary hydrogens.
+        mol = Chem.RemoveHs(mol)
+        return mol
 
 
 def set_structure(mol, cmat, atom_list):

--- a/mdstates/molecules.py
+++ b/mdstates/molecules.py
@@ -31,7 +31,7 @@ def contact_matrix_to_SMILES(cmat, atom_list):
 
 
 def cmat_to_structure(cmat, atom_list):
-    """Converts a contact matrix to a SMILES string.
+    """Converts a contact matrix to a SMILES string and molecule.
 
     Parameters
     ----------

--- a/mdstates/molecules.py
+++ b/mdstates/molecules.py
@@ -30,6 +30,34 @@ def contact_matrix_to_SMILES(cmat, atom_list):
     return smiles
 
 
+def cmat_to_structure(cmat, atom_list):
+    """Converts a contact matrix to a SMILES string.
+
+    Parameters
+    ----------
+    cmat : numpy.ndarray
+        Contact matrix describing connectivity in a molecule.
+    atom_list : array-like
+        Atom list with indices matching indices in contact matrix for
+        atom type identification.
+
+    Returns
+    -------
+    smiles : str
+        SMILES string of molecule built from contact matrix.
+    mol : rdkit.Chem.Mol
+        Molecule built from contact matrix.
+    """
+
+    # Build the molecule
+    mol = build_molecule(cmat, atom_list)
+
+    # Generate SMILES string from molecule
+    smiles = Chem.MolToSmiles(mol)
+
+    return smiles, mol
+
+
 def build_molecule(cmat, atom_list):
     """Builds a molecule from a contact matrix and list of atoms.
 

--- a/mdstates/smiles.py
+++ b/mdstates/smiles.py
@@ -2,6 +2,7 @@ from itertools import groupby
 import shutil
 import os.path
 
+import pandas as pd
 from rdkit import Chem
 from rdkit.Chem import Draw
 from rdkit.Chem.Draw import DrawingOptions
@@ -151,19 +152,19 @@ def remove_consecutive_repeats(smiles):
     true_list : list
         List with all consecutive repeats removed.
     """
-    true_list = []
-    ref = smiles[0][0]
-    true_list.append(smiles[0])
+    reduced = pd.DataFrame(columns=['smiles', 'molecule', 'frame',
+                                    'transition_frame'])
+    ref = smiles.loc[0, 'smiles']
+    reduced = reduced.append(smiles.iloc[0], ignore_index=True)
 
-    for i, smi in enumerate(smiles):
+    for i, row in smiles.iterrows():
         if i == 0:
             continue
 
-        if smi[0] != ref:
-            true_list.append(smi)
-            ref = smi[0]
-
-    return true_list
+        if row['smiles'] != ref:
+            reduced = reduced.append(row, ignore_index=True)
+            ref = row['smiles']
+    return reduced
 
 
 def uniqueSMILES(smiles_list):

--- a/mdstates/tests/test_cases/test_load.txt
+++ b/mdstates/tests/test_cases/test_load.txt
@@ -1,9 +1,9 @@
 CCl.[F-]
 replica0
-CCl.[F-],1
-CF.[Cl-],100
-CCl.[F-],200
+1|1|CCl.[F-]|
+100|100|CF.[Cl-]|
+200|200|CCl.[F-]|
 replica1
-CCl.[F-],1
-CF.[Cl-],300
-CCl.[F-],500
+1|1|CCl.[F-]|
+300|300|CF.[Cl-]|
+500|500|CCl.[F-]|

--- a/mdstates/tests/test_cases/test_load.txt
+++ b/mdstates/tests/test_cases/test_load.txt
@@ -1,9 +1,9 @@
 CCl.[F-]
 replica0
-1|1|CCl.[F-]|
-100|100|CF.[Cl-]|
-200|200|CCl.[F-]|
+1|1|CCl.[F-]|{"directed": false, "multigraph": false, "graph": {}, "nodes": [{"symbol": "C", "id": 0}, {"symbol": "Cl", "id": 1}, {"symbol": "F", "id": 2}, {"symbol": "H", "id": 3}, {"symbol": "H", "id": 4}, {"symbol": "H", "id": 5}], "links": [{"bond_order": 1, "source": 0, "target": 1}, {"bond_order": 1, "source": 0, "target": 3}, {"bond_order": 1, "source": 0, "target": 4}, {"bond_order": 1, "source": 0, "target": 5}]}
+100|100|CF.[Cl-]|{"directed": false, "multigraph": false, "graph": {}, "nodes": [{"symbol": "C", "id": 0}, {"symbol": "F", "id": 1}, {"symbol": "Cl", "id": 2}, {"symbol": "H", "id": 3}, {"symbol": "H", "id": 4}, {"symbol": "H", "id": 5}], "links": [{"bond_order": 1, "source": 0, "target": 1}, {"bond_order": 1, "source": 0, "target": 3}, {"bond_order": 1, "source": 0, "target": 4}, {"bond_order": 1, "source": 0, "target": 5}]}
+200|200|CCl.[F-]|{"directed": false, "multigraph": false, "graph": {}, "nodes": [{"symbol": "C", "id": 0}, {"symbol": "Cl", "id": 1}, {"symbol": "F", "id": 2}, {"symbol": "H", "id": 3}, {"symbol": "H", "id": 4}, {"symbol": "H", "id": 5}], "links": [{"bond_order": 1, "source": 0, "target": 1}, {"bond_order": 1, "source": 0, "target": 3}, {"bond_order": 1, "source": 0, "target": 4}, {"bond_order": 1, "source": 0, "target": 5}]}
 replica1
-1|1|CCl.[F-]|
-300|300|CF.[Cl-]|
-500|500|CCl.[F-]|
+1|1|CCl.[F-]|{"directed": false, "multigraph": false, "graph": {}, "nodes": [{"symbol": "C", "id": 0}, {"symbol": "Cl", "id": 1}, {"symbol": "F", "id": 2}, {"symbol": "H", "id": 3}, {"symbol": "H", "id": 4}, {"symbol": "H", "id": 5}], "links": [{"bond_order": 1, "source": 0, "target": 1}, {"bond_order": 1, "source": 0, "target": 3}, {"bond_order": 1, "source": 0, "target": 4}, {"bond_order": 1, "source": 0, "target": 5}]}
+300|300|CF.[Cl-]|{"directed": false, "multigraph": false, "graph": {}, "nodes": [{"symbol": "C", "id": 0}, {"symbol": "F", "id": 1}, {"symbol": "Cl", "id": 2}, {"symbol": "H", "id": 3}, {"symbol": "H", "id": 4}, {"symbol": "H", "id": 5}], "links": [{"bond_order": 1, "source": 0, "target": 1}, {"bond_order": 1, "source": 0, "target": 3}, {"bond_order": 1, "source": 0, "target": 4}, {"bond_order": 1, "source": 0, "target": 5}]}
+500|500|CCl.[F-]|{"directed": false, "multigraph": false, "graph": {}, "nodes": [{"symbol": "C", "id": 0}, {"symbol": "Cl", "id": 1}, {"symbol": "F", "id": 2}, {"symbol": "H", "id": 3}, {"symbol": "H", "id": 4}, {"symbol": "H", "id": 5}], "links": [{"bond_order": 1, "source": 0, "target": 1}, {"bond_order": 1, "source": 0, "target": 3}, {"bond_order": 1, "source": 0, "target": 4}, {"bond_order": 1, "source": 0, "target": 5}]}

--- a/mdstates/tests/test_core.py
+++ b/mdstates/tests/test_core.py
@@ -347,7 +347,7 @@ def test_save():
     net.add_replica(traj_path, top_path)
     net.generate_contact_matrix()
     net.decode()
-    net._build_all_networks()
+    net.build_all_networks()
     net.save('test')
     if os.path.exists('test.txt'):
         os.remove('test.txt')

--- a/mdstates/tests/test_core.py
+++ b/mdstates/tests/test_core.py
@@ -5,6 +5,7 @@ import os
 import mdtraj as md
 import numpy as np
 import networkx as nx
+import pandas as pd
 
 from ..core import Network
 # from ..graphs import prepare_graph
@@ -202,7 +203,7 @@ def test_decode():
 
 def test_chemical_equations():
     net = Network()
-    smiles_list = [('A.B.C', 0), ('A.B.D', 10), ('A.E.D', 50)]
+    smiles_list = ['A.B.C', 'A.B.D', 'A.E.D']
 
     reactions = net.chemical_equations(-1, smiles_list)
     assert len(reactions) == 2, "List of equations not correct."
@@ -281,9 +282,14 @@ def test_build_network():
     true_net.add_edge('C', 'CC', count=1, traj_count=1, frames=[20])
     true_net.add_edge('CC', 'CCC', count=1, traj_count=1, frames=[34])
 
+    test_df = pd.DataFrame({'smiles': ['C', 'O', 'C', 'CC', 'CCC'],
+                            'molecule': [None for _ in range(5)],
+                            'frame': [0, 6, 11, 20, 34],
+                            'transition_frame': [0, 6, 11, 20, 34]})
     net = Network()
-    test_net = net._build_network(test_list)
-    shutil.rmtree('SMILESimages')
+    net.replica.append({'structures': test_df})
+    test_net = net._build_network(rep_id=0)
+    # shutil.rmtree('SMILESimages')
 
     for node, data in true_net.nodes(data=True):
         assert node in test_net.nodes
@@ -355,16 +361,29 @@ def test_load():
     net = Network()
     test_file = os.path.join(currentdir, 'test_cases', 'test_load.txt')
     net.load(test_file)
-
+    true1 = pd.DataFrame({'smiles': ['CCl.[F-]', 'CF.[Cl-]', 'CCl.[F-]'],
+                          'molecules': [None, None, None],
+                          'frame': [1, 100, 200],
+                          'transition_frame': [1, 100, 200]})
+    true2 = pd.DataFrame({'smiles': ['CCl.[F-]', 'CF.[Cl-]', 'CCl.[F-]'],
+                          'molecules': [None, None, None],
+                          'frame': [1, 300, 500],
+                          'transition_frame': [1, 300, 500]})
+    true_dfs = [true1, true2]
     assert len(net.replica) == 2
-    assert net.replica[0]['smiles'] == [('CCl.[F-]', 1),
-                                        ('CF.[Cl-]', 100),
-                                        ('CCl.[F-]', 200)]
-    assert net.replica[1]['smiles'] == [('CCl.[F-]', 1),
-                                        ('CF.[Cl-]', 300),
-                                        ('CCl.[F-]', 500)]
-    for rep in net.replica:
-        rep['network'] = net._build_network(rep['smiles'])
+    for rep, true_df in zip(net.replica, true_dfs):
+        assert np.all(rep['structures']['smiles'] == true_df['smiles'])
+        assert np.all(rep['structures']['transition_frame'] ==\
+            true_df['transition_frame'])
+
+    # assert net.replica[0]['smiles'] == [('CCl.[F-]', 1),
+                                        # ('CF.[Cl-]', 100),
+                                        # ('CCl.[F-]', 200)]
+    # assert net.replica[1]['smiles'] == [('CCl.[F-]', 1),
+                                        # ('CF.[Cl-]', 300),
+                                        # ('CCl.[F-]', 500)]
+    for i, rep in enumerate(net.replica):
+        rep['network'] = net._build_network(i)
 
     # compiled = net._compile_networks()
     # net.network = compiled

--- a/mdstates/tests/test_smiles.py
+++ b/mdstates/tests/test_smiles.py
@@ -1,5 +1,8 @@
 from collections import Counter
 
+import numpy as np
+import pandas as pd
+
 from ..smiles import (get_mol_dict, remove_common_molecules,
                       to_chemical_equation, find_reaction,
                       remove_consecutive_repeats, uniqueSMILES)
@@ -88,10 +91,19 @@ def test_find_reaction():
 
 def test_remove_consecutive_repeats():
     test_list = ['a', 'a', 'a', 'b', 'c', 'c', 'a']
-
     true_after = ['a', 'b', 'c', 'a']
-    test_after = remove_consecutive_repeats(test_list)
-    assert true_after == test_after, "Lists not the same."
+    test_df = pd.DataFrame({'smiles': test_list,
+                            'molecule': test_list,
+                            'frame': list(range(len(test_list))),
+                            'transition_frame': list(range(len(test_list)))})
+    true_df_after = pd.DataFrame({'smiles': true_after,
+                                  'molecule': true_after,
+                                  'frame': [0, 3, 4, 6],
+                                  'transition_frame': [0, 3, 4, 6]})
+    test_df_after = remove_consecutive_repeats(test_df)
+    for col in test_df_after:
+        assert np.all(true_df_after[col] == test_df_after[col]),\
+            "Lists not the same."
     return
 
 

--- a/mdstates/util.py
+++ b/mdstates/util.py
@@ -1,8 +1,36 @@
+import json
+import os.path
 from os.path import abspath, dirname, join
 from numbers import Number
 
 import numpy as np
 import pandas as pd
+
+
+def json_to_string(json_dict):
+    return json.dumps(json_dict)
+
+
+def json_to_file(json_dict, filename):
+    with open(filename, 'w') as f:
+        json.dump(json_dict, f)
+    return
+
+
+def load_json_from_file(filename):
+    if os.path.exists(filename):
+        pass
+    else:
+        raise FileNotFoundError("File not found: {}".format(filename))
+
+    with open(filename, 'r') as f:
+        json_dict = json.load(f)
+    return json_dict
+
+
+def load_json_from_string(json_string):
+    json_dict = json.loads(json_string)
+    return json_dict
 
 
 def getpath(filename):


### PR DESCRIPTION
In this PR, 2 things changed: the structure of the results of processed trajectories and `save`/`load` methods now work and allow full network analysis without having to reprocess trajectories.

Regarding the first change, each `replica` has a `structures` key in its dictionary which consists of a `pandas.DataFrame`. In the `DataFrame`, there are 4 columns: `frame`, `transition_frame`, `smiles`, `molecule`. `Frame` is simply the frame number from which the structure was built. `Transition_frame` is the transition, or reaction, frame number that `frame` is closest to. `Smiles` is the SMILES string of the structure. And `molecule` is an `rdkit.Chem.Mol` that has explicit hydrogens.

On the 2nd change, `save` and `load` work properly and work off of the `DataFrames` in `replica[...]['structures']`. The methods `build_network` and `build_all_networks` read from these `DataFrames`, so no trajectories need to be reprocessed since the save file contains all information that would be necessary for network analysis.